### PR TITLE
Make creation of fake package environment friendly to byte-code interpreter

### DIFF
--- a/R/package.skeleton.dx.R
+++ b/R/package.skeleton.dx.R
@@ -400,13 +400,10 @@ code
   # some functionality of apply.parsers (evaluating the sources again)
   # but I am not sure how big the changes involved woud be.
   
-  e <- new.env()
+  e <- fake_package_env()
   old <- options(keep.source=TRUE,topLevelEnvironment=e)
   on.exit(options(old))
   exprs <- parse(text=code)
-  ## set this so that no warnings about creating a fake
-  ## package when we try to process S4 classes defined in code
-  e$.packageName <- "inlinedocs.processor"
   for (i in exprs){
       eval(i, e)
   }

--- a/R/parsers.R
+++ b/R/parsers.R
@@ -934,7 +934,7 @@ apply.parsers <- function
  ...
 ### Additional arguments to pass to Parser Functions.
  ){
-  e <- new.env()
+  e <- fake_package_env()
   ## KMP 2011-03-09 fix problem with DocLink when inlinedocs ran on itself
   ## Error in assignClassDef(Class, classDef, where) :
   ##   Class "DocLink" has a locked definition in package "inlinedocs"
@@ -945,9 +945,6 @@ apply.parsers <- function
   old <- options(keep.source=TRUE,topLevelEnvironment=e)
   on.exit(options(old))
   exprs <- parse(text=code)
-  ## TDH 2011-04-07 set this so that no warnings about creating a fake
-  ## package when we try to process S4 classes defined in code
-  e$.packageName <- "inlinedocs.processor"
   for (i in exprs){
       eval(i, e)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -93,3 +93,18 @@ fixPackageFileNames <- function(list){
   list0
 }
 
+### Create a fake package environment in a way that keeps S4 working (so
+### there is a .packageName) and also conforms to byte-code interpreter
+### requirements on environment structure, particularly ensuring that the
+### created environment is a namespace.  A similar procedure (with the
+### exception of not deleting objects) is now in testthat (test_pkg_env).
+fake_package_env <- function() {
+  idocsns <- getNamespace("inlinedocs")
+  e <- list2env(as.list(idocsns, all.names = TRUE), parent = parent.env(idocsns))
+    # deep copies the inlinedocs namespace environment
+    # including all meta-data, so the result will be a namespace
+  rm(list=ls(e), envir=e)
+    # deletes regular objects, but keeps the namespace meta-data
+    # and also .packageName
+  e
+}

--- a/man/fake_package_env.Rd
+++ b/man/fake_package_env.Rd
@@ -1,0 +1,18 @@
+\name{fake_package_env}
+\alias{fake_package_env}
+\title{fake package env}
+\description{Create a fake package environment in a way that keeps S4 working (so
+there is a .packageName) and also conforms to byte-code interpreter
+requirements on environment structure, particularly ensuring that the
+created environment is a namespace.  A similar procedure (with the
+exception of not deleting objects) is now in testthat (test_pkg_env).}
+\usage{fake_package_env()}
+
+
+
+\author{Toby Dylan Hocking <toby@sg.cs.titech.ac.jp> [aut, cre], Keith Ponting [aut], Thomas Wutzler [aut], Philippe Grosjean [aut], Markus Müller [aut], R Core Team [ctb, cph]}
+
+
+
+
+


### PR DESCRIPTION
This patch modified the way inlinedocs creates a fake package environment. In the original version, the fake package environment is not a namespace, which violates the requirements of the byte-code compiler and prevents compilation of certain functions. The fixed version ensures compatibility with the byte-code compiler (while still working with the AST interpreter). A similar procedure of creating a fake package environment exists in testthat and there it has already been fixed in a similar way (function test_pkg_env).
